### PR TITLE
Event Name add in CSV data file

### DIFF
--- a/Assets/LoggingManager.cs
+++ b/Assets/LoggingManager.cs
@@ -50,10 +50,10 @@ public class LoggingManager : MonoBehaviour
         // Add the database columns
         logCollection.Add("Email", new List<string>());
         logCollection.Add("DateAdded", new List<string>());
-        logCollection.Add("UserID", new List<string>());
+        logCollection.Add("ParticipantNumber", new List<string>());
         logCollection.Add("CircleName", new List<string>());
         logCollection.Add("EyeTrackAccuracy", new List<string>());
-        logCollection.Add("Comment", new List<string>());
+        logCollection.Add("CustomCondition", new List<string>());
         logCollection.Add("ShowGazeDot", new List<string>());
         logCollection.Add("ShowGrid", new List<string>());
         logCollection.Add("SpacebarInteract", new List<string>());
@@ -61,10 +61,10 @@ public class LoggingManager : MonoBehaviour
         metaCollection = new Dictionary<string, List<string>>();
         metaCollection.Add("Email", new List<string>());
         metaCollection.Add("DateAdded", new List<string>());
-        metaCollection.Add("UserID", new List<string>());
+        metaCollection.Add("ParticipantNumber", new List<string>());
         metaCollection.Add("CircleName", new List<string>());
         metaCollection.Add("EyeTrackAccuracy", new List<string>());
-        metaCollection.Add("Comment", new List<string>());
+        metaCollection.Add("CustomCondition", new List<string>());
         metaCollection.Add("ShowGazeDot", new List<string>());
         metaCollection.Add("ShowGrid", new List<string>());
         metaCollection.Add("SpacebarInteract", new List<string>());
@@ -84,7 +84,7 @@ public class LoggingManager : MonoBehaviour
             startTime = 0f;
             metaCollection["Email"].Add(emailInputField.text);
 
-            metaCollection["UserID"].Add(userInputField.text);
+            metaCollection["ParticipantNumber"].Add(userInputField.text);
             if (showGazeDot)
             {
                 metaCollection["ShowGazeDot"].Add("On");
@@ -113,11 +113,11 @@ public class LoggingManager : MonoBehaviour
             }
             if (string.IsNullOrEmpty(commentInputField.text))
             {
-                metaCollection["Comment"].Add("No Condition");
+                metaCollection["CustomCondition"].Add("No Condition");
             }
             else
             {
-                metaCollection["Comment"].Add(commentInputField.text);
+                metaCollection["CustomCondition"].Add(commentInputField.text);
             }
 
             hasLoggedCalibration = true;
@@ -129,11 +129,11 @@ public class LoggingManager : MonoBehaviour
     public void DuplicateMetaColumns()
     {
         logCollection["Email"].Add(metaCollection["Email"][0]);
-        logCollection["UserID"].Add(metaCollection["UserID"][0]);
+        logCollection["ParticipantNumber"].Add(metaCollection["ParticipantNumber"][0]);
         logCollection["ShowGazeDot"].Add(metaCollection["ShowGazeDot"][0]);
         logCollection["ShowGrid"].Add(metaCollection["ShowGrid"][0]);
         logCollection["SpacebarInteract"].Add(metaCollection["SpacebarInteract"][0]);
-        logCollection["Comment"].Add(metaCollection["Comment"][0]);
+        logCollection["CustomCondition"].Add(metaCollection["CustomCondition"][0]);
     }
 
     public void WriteToLog(string varName, string varValue)

--- a/Assets/Scripts/CircleTest/Target/SpawnCircle.cs
+++ b/Assets/Scripts/CircleTest/Target/SpawnCircle.cs
@@ -5,7 +5,8 @@ using UnityEngine.UI;
 using System.Linq;
 using System;
 
-public enum SpawnArea {
+public enum SpawnArea
+{
     UpperLeft,
     UpperCenter,
     UpperRight,
@@ -19,7 +20,6 @@ public enum SpawnArea {
 
 public class SpawnCircle : MonoBehaviour
 {
-
     public GameObject spawnObject;
     public GameObject gazeDot;
 
@@ -37,7 +37,7 @@ public class SpawnCircle : MonoBehaviour
 
     private int index;
     public Text countObj;
-    private float countDown = 3f;
+    public static float countDown = 3f;
 
     private bool hasLogged = true;
 
@@ -45,6 +45,7 @@ public class SpawnCircle : MonoBehaviour
     public List<GameObject> offsetGazeList = new List<GameObject>();
 
     LoggingManager loggingManager;
+    LoggerBehavior loggerBehavior;
 
     private float currentEyeAccuracy = -1f;
 
@@ -53,6 +54,7 @@ public class SpawnCircle : MonoBehaviour
     {
         index = 0;
         loggingManager = GameObject.Find("LoggingManager").GetComponent<LoggingManager>();
+        loggerBehavior = GameObject.Find("Pupil Manager").GetComponent<LoggerBehavior>();
     }
 
     // Update is called once per frame
@@ -72,7 +74,6 @@ public class SpawnCircle : MonoBehaviour
 
         //if there is no circle on the grid
         if (targetCircle.Count < 1) {
-
             if (!hasLogged) {
                 Debug.Log("Logging circle for " + Enum.GetName(typeof(SpawnArea), (SpawnArea)index));
                 string date = System.DateTime.Now.ToString("yyyy-MM-dd HH:mm:ss");
@@ -87,7 +88,6 @@ public class SpawnCircle : MonoBehaviour
             //else we show the result of the test
             if (isVisited.Contains(false))
             {
-
                 //get a random index which is not a visited position
                 index = UnityEngine.Random.Range(0, 9);
                 while (isVisited[index] == true)
@@ -101,8 +101,9 @@ public class SpawnCircle : MonoBehaviour
             }
             else
             {
-                loggingManager.UploadLogs();
                 Result();
+                loggerBehavior.SetBoolTest(true);
+                loggingManager.UploadLogs();
             }
         } else {
             currentEyeAccuracy = 1f - targetCircle[targetCircle.Count-1].transform.localScale.x * (1f / 30f);

--- a/Assets/Scripts/Logging/AppConstants.cs
+++ b/Assets/Scripts/Logging/AppConstants.cs
@@ -25,7 +25,7 @@ public static class AppConstants
     //First row, name of the columns, need to be in the same order as the tmp var in AddToLog in LoggerBehavior script
     public const string CSVUserConfigRow = "UserID;Date - Time;Wearing make-up;Wearing glasses;gaze dot displayed;grid displayed;using input;target lifespan (ms);";
 
-    public const string CsvFirstRow = "Session Time (s);SystemDateTime;Scene Name;Scene Timer (s);framerate (fps);circlename;circle_pos_x;circle_pos_y;" +
+    public const string CsvFirstRow = "Session Time (s);SystemDateTime;Scene Name;Event Name;Scene Timer (s);framerate (fps);circlename;circle_pos_x;circle_pos_y;" +
      "pupilData_gaze_x;pupilData_gaze_y;gaze_on_grid_x;gaze_on_grid_y;Left_eye_conf;Right_eye_conf;gaze_confidence;" +
      "circle_radius;accuracyCalc;Offset X;Offset Y;Time To First Fix (s);";
 

--- a/Assets/Scripts/Logging/LoggerBehavior.cs
+++ b/Assets/Scripts/Logging/LoggerBehavior.cs
@@ -6,41 +6,43 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
-using System.IO;
-using UnityEngine;
 using System.Linq;
+using UnityEngine;
 
 public class LoggerBehavior : MonoBehaviour
 {
-
     private static Logger _logger;
     private static List<object> _toLog;
-
-    private LoggingManager loggingManager; // this logging manager facilitates uploading to DB.
-
-    private Vector3 gazeToWorld;
     private static string CSVheader = AppConstants.CsvFirstRow;
     private static string CSVuserConfig = AppConstants.CSVUserConfigRow;
+    public static float sceneTimer = 0;
+    public static string sceneName = "";
+    public static int circleIndex = -1;
+
+    private float accuracyCalc;
+    private bool calibration, countingDown, testRunning;
+
+    private string circleLabel;
 
     //CircleTruc log var
     private GameObject circleObject;
-    private string gazePosx, gazePosy;
     private double circleXpos, circleYpos;
-    private float TTFF;
-    public static float sceneTimer = 0;
-    public static string sceneName = "";
-    private float timer;
-
-    private string circleLabel;
-    private int circleIndex = -1;
-
-    private float accuracyCalc;
     private IEnumerator coroutine;
+    private string gazePosx, gazePosy;
+
+    private Vector3 gazeToWorld;
+
+    private LoggingManager loggingManager; // this logging manager facilitates uploading to DB.
 
     private string systemDateTime;
 
-    //private Camera dedicatedCapture;
+    private float timer;
+    private float TTFF;
 
+    private bool testEnded = false;
+    private string eventName;
+
+    //private Camera dedicatedCapture;
 
     #region Unity Methods
 
@@ -74,11 +76,10 @@ public class LoggerBehavior : MonoBehaviour
             AddToLog();
             yield return new WaitForSeconds(waitTime);
         }
-
     }
 
     /// <summary>
-    /// get the data from the targets from the accuracy test scene
+    ///     get the data from the targets from the accuracy test scene
     /// </summary>
     private void CircleInfo()
     {
@@ -94,11 +95,12 @@ public class LoggerBehavior : MonoBehaviour
     private void AddToLog()
     {
         if (PupilData._2D.GazePosition != Vector2.zero)
-        {
             gazeToWorld = Camera.main.ViewportToWorldPoint(new Vector3
             (PupilData._2D.GazePosition.x, PupilData._2D.GazePosition.y,
-            Camera.main.nearClipPlane));
-        }
+                Camera.main.nearClipPlane));
+
+        // Method called to define the current event
+        SetEventBoolean();
 
         //all the datas that will be saved in the log file
         //1 variable = 1 column
@@ -108,41 +110,35 @@ public class LoggerBehavior : MonoBehaviour
             a = Math.Round(timer, 3),
             // system date time
             systemDateTime = System.DateTime.Now.ToString("yyyy-MM-dd HH:mm:ss.fff"),
-
             //check if we are in accuracy test or fov calibration scene
             sname = sceneName != "" ? sceneName : "No test scene",
+            // event name
+            ename = eventName,
             //scene timer
             stimer = Math.Round(sceneTimer, 3) != 0 ? Math.Round(sceneTimer, 3) : double.NaN,
             //frames per second during the last frame, could calculate an average frame rate instead
             fps = (int)(1.0f / Time.deltaTime),
-
             // circleLabel
-            circleLabel = circleIndex != -1 ? Enum.GetName(typeof(SpawnArea), (SpawnArea)circleIndex) : "None",
-
+            circleLabel = circleObject != null ? Enum.GetName(typeof(SpawnArea), (SpawnArea)circleIndex) : "None",
             //targets position from the accuracy test scene
             logcircleXpos = circleObject != null ? Math.Round(circleObject.transform.localPosition.x, 3) : double.NaN,
             logcircleYpos = circleObject != null ? Math.Round(circleObject.transform.localPosition.y, 3) : double.NaN,
-
             //gaze position on X and Y
             j = PupilData._2D.GazePosition != Vector2.zero ? Math.Round(PupilData._2D.GazePosition.x, 3) : double.NaN,
             k = PupilData._2D.GazePosition != Vector2.zero ? Math.Round(PupilData._2D.GazePosition.y, 3) : double.NaN,
             // l = PupilData._2D.GazePosition != Vector2.zero ? Math.Round(gazeToWorld.x, 3) : double.NaN,
             // m = PupilData._2D.GazePosition != Vector2.zero ? Math.Round(gazeToWorld.y, 3) : double.NaN,
-
             //gaze position on the grid of the accuracy test
             lbis = gazePosx,
             mbis = gazePosy,
-
             //Confidence from left / right eye and the average of both
             // n = PupilData._2D.GazePosition != Vector2.zero ? Math.Round(PupilTools.FloatFromDictionary(PupilTools.gazeDictionary, "confidence"), 3) : double.NaN, // confidence value calculated after calibration 
             confLeft = PupilData._2D.GazePosition != Vector2.zero ? Math.Round(PupilLabData.confidence1, 3) : double.NaN, // confidence value calculated after calibration 
             confRight = PupilData._2D.GazePosition != Vector2.zero ? Math.Round(PupilLabData.confidence0, 3) : double.NaN, // confidence value calculated after calibration 
             confGaze = PupilData._2D.GazePosition != Vector2.zero ? Math.Round((PupilLabData.confidence0 + PupilLabData.confidence1) / 2, 3) : double.NaN,
-
             //target size in the accuracy test scene, can be translated to the offset from the center of the scene
             circleSize = circleObject != null ? Math.Round(circleObject.transform.localScale.x, 3) : double.NaN,
             accuracyCalc = circleObject != null ? circleObject.transform.localScale.x * (1f / 30f) : double.NaN,
-
             offsetX = Math.Round(Convert.ToSingle(gazePosx) - circleXpos, 3),
             offsetY = Math.Round(Convert.ToSingle(gazePosy) - circleYpos, 3),
             //TTFF of the targets in the accuracy test scene
@@ -201,5 +197,52 @@ public class LoggerBehavior : MonoBehaviour
         _logger.Log(_toLog.ToArray());
         _toLog.Clear();
     }
+
+    private void SetEventName()
+    {
+        if (calibration) eventName = "Calibration is running.";
+        else if (countingDown) eventName = "Accuracy Test is counting down.";
+        else if (testRunning) eventName = "Accuracy Test is running.";
+        else eventName = "Accuracy Test ended.";
+    }
+
+    private void SetEventBoolean()
+    {
+        if (sceneName == "")
+        {
+            calibration = true;
+            countingDown = false;
+            testRunning = false;
+        }
+        else
+        {
+            if (SpawnCircle.countDown >= 0)
+            {
+                calibration = false;
+                countingDown = true;
+                testRunning = false;
+            }
+            else if (testEnded)
+            {
+                calibration = false;
+                countingDown = false;
+                testRunning = false;
+            }
+            else
+            {
+                calibration = false;
+                countingDown = false;
+                testRunning = true;
+            }
+        }
+
+        SetEventName();
+    }
+
+    public void SetBoolTest(bool test)
+    {
+        testEnded = test;
+    }
+
     #endregion
 }

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Logs the accuracy for each circle and how much time the participant had to dimin
  * **Target lifespan (ms)**: Lifespan of the targets if the input mode is off (e.g. 4500)
  * **Session Time**: sessions timer, application running since, in seconds (e.g. 58.432)
  * **Scene Name**: current Unity scene's name
- * **Event**: current event running (e.g. Configuration is running, Calibration is running, Accuracy Test is counting down, Accuracy Test is running, Accuracy Test ended)
+ * **Event Name**: current event running during the calibration and accuracy test (e.g. Calibration is running, Accuracy Test is counting down, Accuracy Test is running, Accuracy Test ended)
  * **Scene Timer**: current Unity scene's timer, Unity scene running since, in seconds (e.g. 58.432)
  * **framerate**: current framerate fps (e.g. 60)
  * **circle_pos_x**: target's x position on the accuracy test on the grid (-30 left 0 middle 30 right)


### PR DESCRIPTION
When the program is running, a CSV file is registed in your local files at path `C:\Users\username\Documents\_GazeData`. Now this CSV file contains a new column named `Event Name`. 
The different events name are:
- Calibration is running.
- Accuracy Test is counting down.
- Accuracy Test is running.
- Accuracy Test ended.

We have not any event for the configuration, because the logger work actually only during calibration and accuracy test. README file was updated in consequence of this.

Pictures of CSV file logged Event Name:
![image](https://user-images.githubusercontent.com/23256059/70805125-845b8600-1db8-11ea-8227-149384c93050.png)
![image](https://user-images.githubusercontent.com/23256059/70805195-a5bc7200-1db8-11ea-8828-68c7649fc14d.png)

If you have any data logged during accuracy test but not have a circle on screen (like time between two circles), before circle name and position was same at last data logged: But now is `None` and `NaN` values.
![image](https://user-images.githubusercontent.com/23256059/70805424-2da27c00-1db9-11ea-8871-61bab5d7f97a.png)

Event Name added in CSV file according with issue #18.