### PR TITLE
Change VR Visuals

### DIFF
--- a/Assets/LoggingManager.cs
+++ b/Assets/LoggingManager.cs
@@ -31,9 +31,6 @@ public class LoggingManager : MonoBehaviour
     private InputField commentInputField;
 
     [SerializeField]
-    private Dropdown switchInputDropdown;
-
-    [SerializeField]
     private Text errorField;
 
     private bool spacebarInteract = true, showGrid = true, showGazeDot = true, hasLoggedCalibration = false;
@@ -44,7 +41,7 @@ public class LoggingManager : MonoBehaviour
     private StartConfig startConfig;
 
     void Awake()
-    {
+    {        
         logCollection = new Dictionary<string, List<string>>();
 
         // Add the database columns
@@ -78,6 +75,11 @@ public class LoggingManager : MonoBehaviour
     {
         if (!CheckEmptyValue(emailInputField.text, userInputField.text, testInputField.text)) return;
         if (errorField.text != "") return;
+
+        startConfig.startCalibration();
+
+        showGrid = StartConfig.grid;
+        spacebarInteract = StartConfig.inputMode;
 
         if (!hasLoggedCalibration)
         {
@@ -123,7 +125,6 @@ public class LoggingManager : MonoBehaviour
             hasLoggedCalibration = true;
 
         }
-        startConfig.startCalibration();
     }
 
     public void DuplicateMetaColumns()

--- a/Assets/Materials/CircleColor.mat
+++ b/Assets/Materials/CircleColor.mat
@@ -7,7 +7,7 @@ Material:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
   m_Name: CircleColor
-  m_Shader: {fileID: 46, guid: 0000000000000000f000000000000000, type: 0}
+  m_Shader: {fileID: 10755, guid: 0000000000000000f000000000000000, type: 0}
   m_ShaderKeywords: 
   m_LightmapFlags: 4
   m_EnableInstancingVariants: 0
@@ -72,5 +72,5 @@ Material:
     - _UVSec: 0
     - _ZWrite: 1
     m_Colors:
-    - _Color: {r: 0.19607843, g: 0.19607843, b: 0.19607843, a: 1}
+    - _Color: {r: 0.8705883, g: 0.8705883, b: 0.8705883, a: 1}
     - _EmissionColor: {r: 0, g: 0, b: 0, a: 1}

--- a/Assets/Materials/TriggerColor.mat
+++ b/Assets/Materials/TriggerColor.mat
@@ -7,7 +7,7 @@ Material:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
   m_Name: TriggerColor
-  m_Shader: {fileID: 46, guid: 0000000000000000f000000000000000, type: 0}
+  m_Shader: {fileID: 10755, guid: 0000000000000000f000000000000000, type: 0}
   m_ShaderKeywords: 
   m_LightmapFlags: 4
   m_EnableInstancingVariants: 0

--- a/Assets/Prefabs/Circle.prefab
+++ b/Assets/Prefabs/Circle.prefab
@@ -241,8 +241,10 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 1f7b1cbea7501d44cbdbd1c9ef2a5a2a, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  TTFF: 0
+  index: -1
   isTTFF: 0
+  lifeTime: 0
+  TTFF: 0
 --- !u!114 &114423894905430632
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -288,7 +290,7 @@ RectTransform:
   m_GameObject: {fileID: 1039620438093140}
   m_LocalRotation: {x: 0.7071068, y: 0, z: 0, w: 0.7071068}
   m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 30, y: 0.01, z: 30}
+  m_LocalScale: {x: 28, y: 0.01, z: 28}
   m_Children:
   - {fileID: 224482698954865200}
   - {fileID: 224381838014755552}
@@ -308,7 +310,7 @@ RectTransform:
   m_GameObject: {fileID: 1547670784420764}
   m_LocalRotation: {x: 0.7071068, y: 0, z: 0, w: 0.7071068}
   m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 0.10000001, y: 0.01, z: 0.0001}
+  m_LocalScale: {x: 0.3, y: 0.05, z: 0.0001}
   m_Children: []
   m_Father: {fileID: 224270756927665124}
   m_RootOrder: 1
@@ -326,7 +328,7 @@ RectTransform:
   m_GameObject: {fileID: 1166606283840268}
   m_LocalRotation: {x: 0.7071068, y: 0, z: 0, w: 0.7071068}
   m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 0.01, y: 0.100000024, z: 0.00010000002}
+  m_LocalScale: {x: 0.05, y: 0.3, z: 0.00010000002}
   m_Children: []
   m_Father: {fileID: 224270756927665124}
   m_RootOrder: 0

--- a/Assets/Scenes/CircleTest.unity
+++ b/Assets/Scenes/CircleTest.unity
@@ -1004,7 +1004,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
-  m_Color: {r: 0.4811321, g: 0.4811321, b: 0.4811321, a: 1}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 0
   m_OnCullStateChanged:
     m_PersistentCalls:
@@ -1856,7 +1856,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
-  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_Color: {r: 0.3490566, g: 0.3490566, b: 0.3490566, a: 1}
   m_RaycastTarget: 1
   m_OnCullStateChanged:
     m_PersistentCalls:
@@ -2053,7 +2053,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
-  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_Color: {r: 0.3529412, g: 0.3529412, b: 0.3529412, a: 1}
   m_RaycastTarget: 1
   m_OnCullStateChanged:
     m_PersistentCalls:
@@ -2646,7 +2646,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
-  m_Color: {r: 0, g: 1, b: 0, a: 1}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
   m_OnCullStateChanged:
     m_PersistentCalls:
@@ -2719,7 +2719,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
-  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_Color: {r: 0.3529412, g: 0.3529412, b: 0.3529412, a: 1}
   m_RaycastTarget: 1
   m_OnCullStateChanged:
     m_PersistentCalls:

--- a/Assets/Scenes/MainScene.unity
+++ b/Assets/Scenes/MainScene.unity
@@ -148,8 +148,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 217.5, y: -232.2}
-  m_SizeDelta: {x: 395, y: 464.4}
+  m_AnchoredPosition: {x: 154.75, y: -151.25568}
+  m_SizeDelta: {x: 269.5, y: 302.51135}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &2800722
 MonoBehaviour:
@@ -329,8 +329,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 1187, y: -445.5}
-  m_SizeDelta: {x: 750, y: 891}
+  m_AnchoredPosition: {x: 810.5, y: -251.5}
+  m_SizeDelta: {x: 499, y: 503}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &74621455
 MonoBehaviour:
@@ -512,8 +512,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 599, y: -235.79999}
-  m_SizeDelta: {x: 386, y: 371.59998}
+  m_AnchoredPosition: {x: 410.75, y: -122.744316}
+  m_SizeDelta: {x: 260.5, y: 145.48863}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &91261709
 MonoBehaviour:
@@ -676,8 +676,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 327.5, y: -96.02884}
-  m_SizeDelta: {x: 655, y: 54.019226}
+  m_AnchoredPosition: {x: 202, y: -51.81325}
+  m_SizeDelta: {x: 404, y: 24.542168}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &98077387
 MonoBehaviour:
@@ -887,8 +887,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 30.714287, y: -27.009613}
-  m_SizeDelta: {x: 61.428574, y: 54.019226}
+  m_AnchoredPosition: {x: 18.761904, y: -12.271084}
+  m_SizeDelta: {x: 37.523808, y: 24.542168}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &207700903
 MonoBehaviour:
@@ -1093,8 +1093,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 30.714287, y: -27.009613}
-  m_SizeDelta: {x: 61.428574, y: 54.019226}
+  m_AnchoredPosition: {x: 18.761904, y: -12.271084}
+  m_SizeDelta: {x: 37.523808, y: 24.542168}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &211097722
 MonoBehaviour:
@@ -1349,8 +1349,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 406, y: -658.8}
-  m_SizeDelta: {x: 812, y: 464.4}
+  m_AnchoredPosition: {x: 280.5, y: -351.74432}
+  m_SizeDelta: {x: 561, y: 302.51135}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &233072498
 MonoBehaviour:
@@ -1766,8 +1766,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 10, y: -38.884613}
-  m_SizeDelta: {x: 60.47619, y: 77.769226}
+  m_AnchoredPosition: {x: 10, y: -23.373493}
+  m_SizeDelta: {x: 36.57143, y: 46.746986}
   m_Pivot: {x: 0, y: 0.5}
 --- !u!114 &316248075
 MonoBehaviour:
@@ -2339,8 +2339,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 327.5, y: -86.653854}
-  m_SizeDelta: {x: 655, y: 77.76923}
+  m_AnchoredPosition: {x: 202, y: -42.07229}
+  m_SizeDelta: {x: 404, y: 46.746986}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &406279749
 MonoBehaviour:
@@ -2436,8 +2436,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 372.5, y: -827.11536}
-  m_SizeDelta: {x: 655, y: 127.769226}
+  m_AnchoredPosition: {x: 247, y: -454.95178}
+  m_SizeDelta: {x: 404, y: 96.09638}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &409393702
 MonoBehaviour:
@@ -2519,8 +2519,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 193, y: -322.99997}
-  m_SizeDelta: {x: 366, y: 97.19999}
+  m_AnchoredPosition: {x: 130.25, y: -133.75568}
+  m_SizeDelta: {x: 240.5, y: 23.46591}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &422385048
 MonoBehaviour:
@@ -2858,8 +2858,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 406, y: -213.29999}
-  m_SizeDelta: {x: 812, y: 426.59998}
+  m_AnchoredPosition: {x: 280.5, y: -100.244316}
+  m_SizeDelta: {x: 561, y: 200.48863}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &514515720
 MonoBehaviour:
@@ -3020,8 +3020,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 327.5, y: -125.53846}
-  m_SizeDelta: {x: 655, y: 251.07692}
+  m_AnchoredPosition: {x: 202, y: -66.421684}
+  m_SizeDelta: {x: 404, y: 132.84337}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &541307663
 MonoBehaviour:
@@ -3163,8 +3163,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 327.5, y: -234.06729}
-  m_SizeDelta: {x: 655, y: 54.019226}
+  m_AnchoredPosition: {x: 202, y: -130.89758}
+  m_SizeDelta: {x: 404, y: 24.542168}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &578293720
 MonoBehaviour:
@@ -3350,8 +3350,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 30.714287, y: -27.009613}
-  m_SizeDelta: {x: 61.428574, y: 54.019226}
+  m_AnchoredPosition: {x: 18.761904, y: -12.271084}
+  m_SizeDelta: {x: 37.523808, y: 24.542168}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &588073220
 MonoBehaviour:
@@ -3593,8 +3593,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 363.2143, y: -27.009613}
-  m_SizeDelta: {x: 583.5715, y: 54.019226}
+  m_AnchoredPosition: {x: 225.7619, y: -12.271084}
+  m_SizeDelta: {x: 356.4762, y: 24.542168}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &605721714
 MonoBehaviour:
@@ -4131,8 +4131,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 198.5, y: -78.6}
-  m_SizeDelta: {x: 397, y: 157.2}
+  m_AnchoredPosition: {x: 135.75, y: -39.033722}
+  m_SizeDelta: {x: 271.5, y: 78.067444}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &637863573
 MonoBehaviour:
@@ -4193,8 +4193,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 193, y: -86.09999}
-  m_SizeDelta: {x: 366, y: 172.19998}
+  m_AnchoredPosition: {x: 130.25, y: -46.93182}
+  m_SizeDelta: {x: 240.5, y: 93.86364}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &713833583
 MonoBehaviour:
@@ -4282,8 +4282,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 367.7381, y: -38.884613}
-  m_SizeDelta: {x: 574.5238, y: 77.769226}
+  m_AnchoredPosition: {x: 230.28572, y: -23.373493}
+  m_SizeDelta: {x: 347.4286, y: 46.746986}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &721877607
 MonoBehaviour:
@@ -4632,8 +4632,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 213, y: -235.79999}
-  m_SizeDelta: {x: 386, y: 371.59998}
+  m_AnchoredPosition: {x: 150.25, y: -122.744316}
+  m_SizeDelta: {x: 260.5, y: 145.48863}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &761046938
 MonoBehaviour:
@@ -4940,8 +4940,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 372.5, y: -559.92303}
-  m_SizeDelta: {x: 655, y: 251.07692}
+  m_AnchoredPosition: {x: 247, y: -293.73492}
+  m_SizeDelta: {x: 404, y: 132.84337}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &884699866
 MonoBehaviour:
@@ -5024,8 +5024,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 397, y: -464.40002}
-  m_SizeDelta: {x: 397, y: 307.2}
+  m_AnchoredPosition: {x: 271.5, y: -302.51135}
+  m_SizeDelta: {x: 271.5, y: 224.44391}
   m_Pivot: {x: 1, y: 0}
 --- !u!114 &893398838
 MonoBehaviour:
@@ -5216,8 +5216,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 193, y: -223.29997}
-  m_SizeDelta: {x: 366, y: 102.19999}
+  m_AnchoredPosition: {x: 130.25, y: -107.943184}
+  m_SizeDelta: {x: 240.5, y: 28.15909}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &945143257
 MonoBehaviour:
@@ -5527,8 +5527,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 363.2143, y: -27.009613}
-  m_SizeDelta: {x: 583.5715, y: 54.019226}
+  m_AnchoredPosition: {x: 225.7619, y: -12.271084}
+  m_SizeDelta: {x: 356.4762, y: 24.542168}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &950032347
 MonoBehaviour:
@@ -5775,6 +5775,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   lifeSpanFieldGameObject: {fileID: 811142289}
+  gridToggle: {fileID: 1418704605}
   userIDValue: {fileID: 636771231}
   targetLifeSpanValue: {fileID: 1602618249}
   targetLifeSpanTxt: {fileID: 1967605422}
@@ -5827,8 +5828,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 372.5, y: -724.34607}
-  m_SizeDelta: {x: 655, y: 77.769226}
+  m_AnchoredPosition: {x: 247, y: -383.53012}
+  m_SizeDelta: {x: 404, y: 46.746986}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &979776288
 MonoBehaviour:
@@ -6071,8 +6072,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 812, y: -464.4}
-  m_SizeDelta: {x: 397, y: 464.4}
+  m_AnchoredPosition: {x: 561, y: -302.51135}
+  m_SizeDelta: {x: 271.5, y: 302.51135}
   m_Pivot: {x: 1, y: 0}
 --- !u!114 &1022649558
 MonoBehaviour:
@@ -6155,8 +6156,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 0, y: -65.40385}
-  m_SizeDelta: {x: 525, y: 40.26923}
+  m_AnchoredPosition: {x: 0, y: -28.364887}
+  m_SizeDelta: {x: 274, y: 14.69191}
   m_Pivot: {x: 0, y: 0.5}
 --- !u!114 &1044775873
 MonoBehaviour:
@@ -6319,8 +6320,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 193, y: -223.29997}
-  m_SizeDelta: {x: 366, y: 102.19999}
+  m_AnchoredPosition: {x: 130.25, y: -107.943184}
+  m_SizeDelta: {x: 240.5, y: 28.15909}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1079618780
 MonoBehaviour:
@@ -6390,7 +6391,7 @@ MonoBehaviour:
   m_outlineColor:
     serializedVersion: 2
     rgba: 4278190080
-  m_fontSize: 20.75
+  m_fontSize: 11.15
   m_fontSizeBase: 36
   m_fontWeight: 400
   m_enableAutoSizing: 1
@@ -6641,8 +6642,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 197.5, y: -214.7}
-  m_SizeDelta: {x: 395, y: 429.4}
+  m_AnchoredPosition: {x: 134.75, y: -133.75568}
+  m_SizeDelta: {x: 269.5, y: 267.51135}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1088192989
 MonoBehaviour:
@@ -6825,8 +6826,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 372.5, y: -303.84613}
-  m_SizeDelta: {x: 655, y: 261.0769}
+  m_AnchoredPosition: {x: 247, y: -155.72891}
+  m_SizeDelta: {x: 404, y: 143.16867}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1096530733
 MonoBehaviour:
@@ -7490,8 +7491,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 327.5, y: -23.884617}
-  m_SizeDelta: {x: 655, y: 47.769234}
+  m_AnchoredPosition: {x: 202, y: -9.349398}
+  m_SizeDelta: {x: 404, y: 18.698795}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1280100210
 MonoBehaviour:
@@ -7554,8 +7555,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 372.5, y: -86.65385}
-  m_SizeDelta: {x: 655, y: 173.3077}
+  m_AnchoredPosition: {x: 247, y: -42.07229}
+  m_SizeDelta: {x: 404, y: 84.14458}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1333808585
 MonoBehaviour:
@@ -7619,8 +7620,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 193, y: -86.09999}
-  m_SizeDelta: {x: 366, y: 172.19998}
+  m_AnchoredPosition: {x: 130.25, y: -46.93182}
+  m_SizeDelta: {x: 240.5, y: 93.86364}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1342312880
 MonoBehaviour:
@@ -7747,8 +7748,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 327.5, y: -165.04807}
-  m_SizeDelta: {x: 655, y: 54.019226}
+  m_AnchoredPosition: {x: 202, y: -91.35542}
+  m_SizeDelta: {x: 404, y: 24.542168}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1352929170
 MonoBehaviour:
@@ -8060,7 +8061,7 @@ MonoBehaviour:
       m_Calls: []
     m_TypeName: UnityEngine.UI.Toggle+ToggleEvent, UnityEngine.UI, Version=1.0.0.0,
       Culture=neutral, PublicKeyToken=null
-  m_IsOn: 1
+  m_IsOn: 0
 --- !u!1 &1429284816
 GameObject:
   m_ObjectHideFlags: 0
@@ -8186,8 +8187,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 406, y: -445.5}
-  m_SizeDelta: {x: 812, y: 891}
+  m_AnchoredPosition: {x: 280.5, y: -251.5}
+  m_SizeDelta: {x: 561, y: 503}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1454701575
 MonoBehaviour:
@@ -8966,8 +8967,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 83.5, y: -63.884613}
-  m_SizeDelta: {x: 167, y: 87.769226}
+  m_AnchoredPosition: {x: 48.79227, y: -48.04819}
+  m_SizeDelta: {x: 97.58454, y: 56.096382}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1616911277
 MonoBehaviour:
@@ -9152,8 +9153,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 193, y: -322.99997}
-  m_SizeDelta: {x: 366, y: 97.19999}
+  m_AnchoredPosition: {x: 130.25, y: -133.75568}
+  m_SizeDelta: {x: 240.5, y: 23.46591}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1668634368
 MonoBehaviour:
@@ -9280,8 +9281,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 363.2143, y: -27.009613}
-  m_SizeDelta: {x: 583.5715, y: 54.019226}
+  m_AnchoredPosition: {x: 225.7619, y: -12.271084}
+  m_SizeDelta: {x: 356.4762, y: 24.542168}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1713498759
 MonoBehaviour:
@@ -9489,8 +9490,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 262.5, y: -208.4423}
-  m_SizeDelta: {x: 525, y: 85.269226}
+  m_AnchoredPosition: {x: 137, y: -108.96902}
+  m_SizeDelta: {x: 274, y: 47.748707}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1717048978
 MonoBehaviour:
@@ -9555,8 +9556,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 262.5, y: -125.67307}
-  m_SizeDelta: {x: 525, y: 60.26923}
+  m_AnchoredPosition: {x: 137, y: -60.402752}
+  m_SizeDelta: {x: 274, y: 29.38382}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1731607315
 MonoBehaviour:
@@ -10167,8 +10168,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 363.2143, y: -27.009613}
-  m_SizeDelta: {x: 583.5715, y: 54.019226}
+  m_AnchoredPosition: {x: 225.7619, y: -12.271084}
+  m_SizeDelta: {x: 356.4762, y: 24.542168}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!1 &1862632505
 GameObject:
@@ -10202,8 +10203,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 327.5, y: -149.42308}
-  m_SizeDelta: {x: 655, y: 47.769234}
+  m_AnchoredPosition: {x: 202, y: -74.79518}
+  m_SizeDelta: {x: 404, y: 18.698795}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1862632507
 MonoBehaviour:
@@ -10470,8 +10471,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 262.5, y: -17.634615}
-  m_SizeDelta: {x: 525, y: 35.26923}
+  m_AnchoredPosition: {x: 137, y: -5.509466}
+  m_SizeDelta: {x: 274, y: 11.018932}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1936398650
 MonoBehaviour:
@@ -10755,7 +10756,7 @@ RectTransform:
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
   m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 655, y: 54.019226}
+  m_SizeDelta: {x: 404, y: 24.542168}
   m_Pivot: {x: 0, y: 1}
 --- !u!114 &2018497001
 MonoBehaviour:
@@ -10852,8 +10853,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 30.714287, y: -27.009613}
-  m_SizeDelta: {x: 61.428574, y: 54.019226}
+  m_AnchoredPosition: {x: 18.761904, y: -12.271084}
+  m_SizeDelta: {x: 37.523808, y: 24.542168}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &2048163613
 MonoBehaviour:
@@ -10942,8 +10943,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 411, y: -63.884613}
-  m_SizeDelta: {x: 488, y: 87.769226}
+  m_AnchoredPosition: {x: 250.79227, y: -48.04819}
+  m_SizeDelta: {x: 306.41547, y: 56.096382}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &2050246461
 MonoBehaviour:

--- a/Assets/Scripts/CircleTest/GameController.cs
+++ b/Assets/Scripts/CircleTest/GameController.cs
@@ -70,10 +70,11 @@ public class GameController : MonoBehaviour
                 {
                     ReduceCircle(hit.transform.gameObject);
                 }
-                else
+                // This part was commented to stop the possibility of each circles grow up after gaze go inside them
+                /*else
                 {
                     ExtendCircle(SpawnCircle.targetCircle[0]);
-                }
+                }*/
             }
         }
     }
@@ -118,7 +119,7 @@ public class GameController : MonoBehaviour
     private void ExtendCircle(GameObject circle)
     {
         //if it's smaller than the max circle size
-        if (circle.transform.localScale.x < 30)
+        if (circle.transform.localScale.x < 28)
         {
             //15f * Time.deltaTime so the computers speed doesn't affect the speed
             circle.transform.localScale =

--- a/Assets/Scripts/CircleTest/Target/CircleLife.cs
+++ b/Assets/Scripts/CircleTest/Target/CircleLife.cs
@@ -40,7 +40,7 @@ public class CircleLife : MonoBehaviour
 
         if (isTTFF) //update TTFF time until the circle is focused by the gaze point (when the scale change)
             TTFF += Time.deltaTime;
-        if (gameObject.transform.localScale.x < 30)
+        if (gameObject.transform.localScale.x < 28)
             isTTFF = false;
 
         if (Input.GetKeyUp(KeyCode.Space) && StartConfig.inputMode)

--- a/Assets/Scripts/CircleTest/Target/CrossController.cs
+++ b/Assets/Scripts/CircleTest/Target/CrossController.cs
@@ -36,19 +36,5 @@ public class CrossController : MonoBehaviour
             else
                 gameObject.GetComponent<MeshRenderer>().enabled = true;
         }
-        //switch the color of the cross
-        waitTime += Time.deltaTime;
-        if (waitTime < timer)
-        {
-            gameObject.GetComponent<Renderer>().material.color = Color.white;
-        }
-        if (waitTime > timer)
-        {
-            gameObject.GetComponent<Renderer>().material.color = Color.green;
-        }
-        if (waitTime > timer * 2)
-        {
-            waitTime = 0;
-        }
     }
 }

--- a/Assets/Scripts/CircleTest/Target/FocusHelper.cs
+++ b/Assets/Scripts/CircleTest/Target/FocusHelper.cs
@@ -4,14 +4,16 @@ using UnityEngine;
 
 public class FocusHelper : MonoBehaviour
 {
-
     public GameObject targetHelper;
     private GameObject newObject;
+    private float circleTimer = 0.3f, circleMaxSize = 28f;
+    private float circleSpeed = 0.3f / 28f;
+
     // Use this for initialization
     void Start()
     {
         //if there is none or more than 1 circle
-        if(SpawnCircle.targetCircle.Count != 1)
+        if (SpawnCircle.targetCircle.Count != 1)
             return;
         //spawn a red circle on the target
         newObject = Instantiate(targetHelper);
@@ -24,14 +26,16 @@ public class FocusHelper : MonoBehaviour
     // Update is called once per frame
     void Update()
     {
+        float lastCircleTimer = circleTimer;
+        circleTimer -= Time.deltaTime;
+
         //if the red circle is destroyed
-        if(newObject == null)
+        if (newObject == null)
             return;
         //decrease the scale of the red circle
-        newObject.transform.localScale = new Vector3(newObject.transform.localScale.x - 0.15f * (Time.deltaTime * 4),
-            newObject.transform.localScale.y - 0.15f * (Time.deltaTime * 4), 1);
+        newObject.transform.localScale = new Vector3(newObject.transform.localScale.x * circleTimer / lastCircleTimer,
+            newObject.transform.localScale.y * circleTimer / lastCircleTimer, 1);
         //when the circle is too small, destroy it
-        if (newObject.transform.localScale.x < 0.05 || gameObject.transform.localScale.x != 28)
-            Destroy(newObject);
+        if (newObject.transform.localScale.x < 0.05 || circleTimer <= 0) Destroy(newObject);
     }
 }

--- a/Assets/Scripts/CircleTest/Target/FocusHelper.cs
+++ b/Assets/Scripts/CircleTest/Target/FocusHelper.cs
@@ -31,7 +31,7 @@ public class FocusHelper : MonoBehaviour
         newObject.transform.localScale = new Vector3(newObject.transform.localScale.x - 0.15f * (Time.deltaTime * 4),
             newObject.transform.localScale.y - 0.15f * (Time.deltaTime * 4), 1);
         //when the circle is too small, destroy it
-        if (newObject.transform.localScale.x < 0.05 || gameObject.transform.localScale.x != 30)
+        if (newObject.transform.localScale.x < 0.05 || gameObject.transform.localScale.x != 28)
             Destroy(newObject);
     }
 }

--- a/Assets/Scripts/CircleTest/Target/SpawnCircle.cs
+++ b/Assets/Scripts/CircleTest/Target/SpawnCircle.cs
@@ -28,7 +28,7 @@ public class SpawnCircle : MonoBehaviour
     new Vector3(-30f,0f,-0.05f), new Vector3(0f,0f,-0.05f), new Vector3(30f,0f,-0.05f),
     new Vector3(-30f,-30f,-0.05f), new Vector3(0f,-30f,-0.05f), new Vector3(30f,-30f,-0.05f)};
 
-    public static float[] circleFinalSize = { 30, 30, 30, 30, 30, 30, 30, 30, 30 };
+    public static float[] circleFinalSize = { 28, 28, 28, 28, 28, 28, 28, 28, 28 };
     public static Vector3[] finalGazePos = new Vector3[9];
     private bool[] isVisited = new bool[9];
     public List<int> indexOrder = new List<int>();
@@ -106,7 +106,7 @@ public class SpawnCircle : MonoBehaviour
                 loggingManager.UploadLogs();
             }
         } else {
-            currentEyeAccuracy = 1f - targetCircle[targetCircle.Count-1].transform.localScale.x * (1f / 30f);
+            currentEyeAccuracy = 1f - targetCircle[targetCircle.Count-1].transform.localScale.x * (1f / 28f);
         }
     }
 
@@ -275,7 +275,7 @@ public class SpawnCircle : MonoBehaviour
                 Destroy(obj);
             }
             goPathList.Clear();
-            circleFinalSize = new float[] { 30, 30, 30, 30, 30, 30, 30, 30, 30 };
+            circleFinalSize = new float[] { 28, 28, 28, 28, 28, 28, 28, 28, 28 };
             finalGazePos = new Vector3[9];
             GazeMarker.gazePath.Clear();
             GazeMarker.savedGazePath.Clear();
@@ -293,7 +293,7 @@ public class SpawnCircle : MonoBehaviour
         targetCircle.Clear();
         offsetGazeList.Clear();
         goPathList.Clear();
-        circleFinalSize = new float[] { 30, 30, 30, 30, 30, 30, 30, 30, 30 };
+        circleFinalSize = new float[] { 28, 28, 28, 28, 28, 28, 28, 28, 28 };
         finalGazePos = new Vector3[9];
         GazeMarker.gazePath.Clear();
         GazeMarker.savedGazePath.Clear();

--- a/Assets/Scripts/Logging/LoggerBehavior.cs
+++ b/Assets/Scripts/Logging/LoggerBehavior.cs
@@ -138,7 +138,7 @@ public class LoggerBehavior : MonoBehaviour
             confGaze = PupilData._2D.GazePosition != Vector2.zero ? Math.Round((PupilLabData.confidence0 + PupilLabData.confidence1) / 2, 3) : double.NaN,
             //target size in the accuracy test scene, can be translated to the offset from the center of the scene
             circleSize = circleObject != null ? Math.Round(circleObject.transform.localScale.x, 3) : double.NaN,
-            accuracyCalc = circleObject != null ? circleObject.transform.localScale.x * (1f / 30f) : double.NaN,
+            accuracyCalc = circleObject != null ? circleObject.transform.localScale.x * (1f / 28f) : double.NaN,
             offsetX = Math.Round(Convert.ToSingle(gazePosx) - circleXpos, 3),
             offsetY = Math.Round(Convert.ToSingle(gazePosy) - circleYpos, 3),
             //TTFF of the targets in the accuracy test scene

--- a/Assets/Scripts/Menu/StartConfig.cs
+++ b/Assets/Scripts/Menu/StartConfig.cs
@@ -11,9 +11,15 @@ public class StartConfig : MonoBehaviour
     public static string userID;
     public static float targetLifeSpan;
     public GameObject lifeSpanFieldGameObject;
+    public Toggle gridToggle;
     public Text userIDValue, targetLifeSpanValue, targetLifeSpanTxt;
     public static bool makeUp = false, glasses = false, gazeDot = true, grid = true, inputMode = true;
     public Dropdown targetLifeSpanDropdown;
+
+    private void Start()
+    {
+        grid = gridToggle.isOn;
+    }
 
     /// <summary>
     /// Save all config variables and start calibration 2D


### PR DESCRIPTION
Before VR Visuals, during the test are really distracting. Colors are too much agressive for eyes and we want the participant only focus on the test. So, I changed colors and others things to be more sweet for eyes.

I change everything to match with what we need in #33.

![image](https://user-images.githubusercontent.com/23256059/72248476-8bfc8d80-35f7-11ea-87b2-a8c2795b778b.png)

Code is updated to control, if we want to show the grid or not. Need to setup it before run Unity in `MainScene`, `DesactivateObjectsFromOptions`, `grid_chekcbox`.
In same time, I connected the dropdown to database logger to know if we choose spacebar intercat or automatic mode.